### PR TITLE
New RiotClient constructor

### DIFF
--- a/Network/ValorantNet.cs
+++ b/Network/ValorantNet.cs
@@ -108,7 +108,7 @@ namespace RadiantConnect.Network
             return new UserAuth(authPort, oAuth);
         }
 
-        private async Task<(string, string)> GetAuthorizationToken()
+        internal async Task<(string, string)> GetAuthorizationToken()
         {
             OnLog?.Invoke("[ValorantNet Log] Getting local AuthorizationTokens");
 
@@ -183,7 +183,7 @@ namespace RadiantConnect.Network
             }
 
             // I no longer need the loop, as the client will now handle edge-cases.
-            if (!InternalValorantMethods.IsValorantProcessRunning() && AuthCodes is null) return string.Empty;
+            if (!(InternalValorantMethods.IsValorantProcessRunning() || InternalValorantMethods.IsRiotClientRunning()) && AuthCodes is null) return string.Empty;
 
             if (baseUrl.Contains("127.0.0.1") && _client.DefaultRequestHeaders.Authorization?.Scheme != "Basic") await SetBasicAuth();
             else if (customHeaders is not null) SetCustomHeaders(customHeaders);

--- a/RConnect/RConnectMethods.cs
+++ b/RConnect/RConnectMethods.cs
@@ -95,6 +95,7 @@ namespace RadiantConnect.RConnect
     public static class RConnectMethods
     {
         public static bool IsValorantRunning() => InternalValorantMethods.IsValorantProcessRunning();
+        public static bool IsRiotClientRunning() => InternalValorantMethods.IsRiotClientRunning();
 
         public static async Task<string?> GetRiotIdByPuuidAsync(this Initiator initiator, string puuid)
         {

--- a/RadiantConnect.csproj
+++ b/RadiantConnect.csproj
@@ -8,7 +8,7 @@
 		<GenerateDocumentationFile>False</GenerateDocumentationFile>
 		<GeneratePackageOnBuild>True</GeneratePackageOnBuild>
 		<Title>Radiant Connect Valorant API (UnOfficial)</Title>
-		<Version>10.1.0</Version>
+		<Version>10.1.1</Version>
 		<Authors>IrisDev</Authors>
 		<PackageProjectUrl>https://radiantconnect.ca/</PackageProjectUrl>
 		<RepositoryUrl>https://github.com/RiisDev/RadiantConnect</RepositoryUrl>
@@ -21,8 +21,7 @@
 		<PackageTags>valorant;valorant api;.net;dotnet;api;xmpp;mitm;authentication;game events;tcp;pvp;socket;realtime;multiplayer;open source;csharp;c#;websocket;game development</PackageTags>
 		<LangVersion>preview</LangVersion>
 		<PackageReleaseNotes>
-			+ New authentication method: `AuthenticateWithRiotClient` refer to documentation for more info.
-			* `AuthenticateWithSsid` now accepts a System.Net.WebProxy parameter.
+			* New Initiator constructor for RiotClient
 		</PackageReleaseNotes>
 		<NeutralLanguage>en</NeutralLanguage>
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/Services/RiotPathService.cs
+++ b/Services/RiotPathService.cs
@@ -17,25 +17,35 @@ namespace RadiantConnect.Services
             {
                 installLocation = @"C:\Riot Games\VALORANT\live\ShooterGame\Binaries\Win64\VALORANT-Win64-Shipping.exe";
             }
-            return installLocation;
+
+			if (!File.Exists(installLocation))
+				throw new FileNotFoundException("Failed to find Valorant executable");
+
+			return installLocation;
         }
 
-        public static string GetRiotClientPath()
+        public static string GetRiotClientPath(bool service = true)
         {
-            string installLocation = string.Empty;
+            string installLocation;
             try
             {
-                string? uninstallString = GetValue($@"{CurrentUser}\Software\Microsoft\Windows\CurrentVersion\Uninstall\Riot Game valorant.live",
-                    "UninstallString", "")?.ToString();
+                string? installString = GetValue($@"{CurrentUser}\Software\Microsoft\Windows\CurrentVersion\Uninstall\Riot Game Riot_Client",
+                    "InstallLocation", "")?.ToString();
 
-                if (uninstallString is not null)
-                    installLocation = uninstallString[1..(uninstallString.IndexOf(".exe", StringComparison.Ordinal) + 4)];
-            }
+                if (!Directory.Exists(installString))
+	                throw new DirectoryNotFoundException("Failed to find Riot Client install path");
+
+				installLocation = service ? Path.Combine(installString, "RiotClientServices.exe") : Path.Combine(installString, "Riot Client.exe");
+			}
             catch
             {
                 installLocation = @"C:\Riot Games\Riot Client\RiotClientServices.exe";
             }
-            return installLocation;
+			
+			if (!File.Exists(installLocation))
+				throw new FileNotFoundException($"Failed to find {(service ? "RiotClientServices" : "Riot Client")} executable");
+
+			return installLocation;
         }
     }
 }

--- a/Utilities/InternalValorantMethods.cs
+++ b/Utilities/InternalValorantMethods.cs
@@ -15,6 +15,7 @@ namespace RadiantConnect.Utilities
 
 		public static bool IsValorantProcessRunning() => Process.GetProcessesByName("VALORANT").Length > 0;
 
+		public static bool IsRiotClientRunning() => Process.GetProcessesByName("RiotClientServices").Length > 0 && Process.GetProcessesByName("Riot Client").Length > 0;
 		internal static async Task<bool> IsReady(LocalEndpoints localEndpoints)
 		{
 			try


### PR DESCRIPTION
* New RiotClient constructor via Initiator, wont write documentation publicly yet till further testing, this is more an update to work with the new RadiantConnect web api 

riotClient must be true, only reason the variable exists is to differentiate as a new constructor, and to help users autofill
`public Initiator(bool riotClient, LogService.ClientData.ShardType shard, bool ignoreVpn = true)`