### PR TITLE
Riot Client Path Fix, Workflow Fix

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -36,4 +36,4 @@ jobs:
       run: dotnet build RadiantConnect.sln --configuration Release --framework net9.0
             
     - name: Test RadiantConnect.Tests
-      run: dotnet test RadiantConnect.Tests/RadiantConnect.Tests.csproj --no-restore --verbosity normal
+      run: dotnet test RadiantConnect.Tests/RadiantConnect.Tests.csproj --filter "TableUnitTest" --no-restore --verbosity normal

--- a/RadiantConnect.csproj
+++ b/RadiantConnect.csproj
@@ -8,7 +8,7 @@
 		<GenerateDocumentationFile>False</GenerateDocumentationFile>
 		<GeneratePackageOnBuild>True</GeneratePackageOnBuild>
 		<Title>Radiant Connect Valorant API (UnOfficial)</Title>
-		<Version>10.1.2</Version>
+		<Version>10.1.3</Version>
 		<Authors>IrisDev</Authors>
 		<PackageProjectUrl>https://radiantconnect.ca/</PackageProjectUrl>
 		<RepositoryUrl>https://github.com/RiisDev/RadiantConnect</RepositoryUrl>
@@ -21,8 +21,7 @@
 		<PackageTags>valorant;valorant api;.net;dotnet;api;xmpp;mitm;authentication;game events;tcp;pvp;socket;realtime;multiplayer;open source;csharp;c#;websocket;game development</PackageTags>
 		<LangVersion>preview</LangVersion>
 		<PackageReleaseNotes>
-			* New Initiator constructor for RiotClient
-			* Fixed GameVersionService (again)
+			* Fixed RiotPathService breaking for Riot Client
 		</PackageReleaseNotes>
 		<NeutralLanguage>en</NeutralLanguage>
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/RadiantConnect.csproj
+++ b/RadiantConnect.csproj
@@ -8,7 +8,7 @@
 		<GenerateDocumentationFile>False</GenerateDocumentationFile>
 		<GeneratePackageOnBuild>True</GeneratePackageOnBuild>
 		<Title>Radiant Connect Valorant API (UnOfficial)</Title>
-		<Version>10.1.1</Version>
+		<Version>10.1.2</Version>
 		<Authors>IrisDev</Authors>
 		<PackageProjectUrl>https://radiantconnect.ca/</PackageProjectUrl>
 		<RepositoryUrl>https://github.com/RiisDev/RadiantConnect</RepositoryUrl>
@@ -22,6 +22,7 @@
 		<LangVersion>preview</LangVersion>
 		<PackageReleaseNotes>
 			* New Initiator constructor for RiotClient
+			* Fixed GameVersionService (again)
 		</PackageReleaseNotes>
 		<NeutralLanguage>en</NeutralLanguage>
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/Services/RiotPathService.cs
+++ b/Services/RiotPathService.cs
@@ -11,7 +11,11 @@ namespace RadiantConnect.Services
             {
                 installLocation = GetValue($@"{CurrentUser}\Software\Microsoft\Windows\CurrentVersion\Uninstall\Riot Game valorant.live",
                     "InstallLocation", "")?.ToString();
-                installLocation += @"\ShooterGame\Binaries\Win64\VALORANT-Win64-Shipping.exe";
+
+                if (installLocation.IsNullOrEmpty())
+	                throw new AccessViolationException("Failed to access registry key for valorant.live");
+
+				installLocation += @"\ShooterGame\Binaries\Win64\VALORANT-Win64-Shipping.exe";
             }
             catch
             {
@@ -29,8 +33,11 @@ namespace RadiantConnect.Services
             string installLocation;
             try
             {
-                string? installString = GetValue($@"{CurrentUser}\Software\Microsoft\Windows\CurrentVersion\Uninstall\Riot Game Riot_Client",
+                string? installString = GetValue($@"{CurrentUser}\Software\Microsoft\Windows\CurrentVersion\Uninstall\Riot Game Riot_Client.",
                     "InstallLocation", "")?.ToString();
+
+                if (installString.IsNullOrEmpty())
+	                throw new AccessViolationException("Failed to access registry key for Riot_Client");
 
                 if (!Directory.Exists(installString))
 	                throw new DirectoryNotFoundException("Failed to find Riot Client install path");

--- a/Services/ValorantService.cs
+++ b/Services/ValorantService.cs
@@ -24,8 +24,8 @@
             string userPlatform = GameVersionService.GetClientPlatform();
             string engineVersion = $"{fileInfo.FileMajorPart}.{fileInfo.FileMinorPart}.{fileInfo.FileBuildPart}.{fileInfo.FilePrivatePart}";
             string branch = versionData.Branch;
-            string buildVersion = versionData.BuildVersion;
-            string changelist = versionData.VersionNumber.ToString();
+            string buildVersion = versionData.VersionNumber.ToString();
+			string changelist = versionData.BuildVersion;
             string clientVersion = versionData.BuiltData;
 
             return new Version(


### PR DESCRIPTION
Fixed grabbing riot client via registry 

Riot Game Riot_Client -> Riot Game Riot_Client. 

My blindness couldn't see the . during development

Fixed workflow to run table test only.