### PR TITLE
10.4.0 | Endpoints, Bug Fixes, New Event

### DIFF
--- a/Network/CurrentGameEndpoints/CurrentGameEndpoints.cs
+++ b/Network/CurrentGameEndpoints/CurrentGameEndpoints.cs
@@ -11,16 +11,38 @@ namespace RadiantConnect.Network.CurrentGameEndpoints
 
 		public async Task<string?> GetCurrentGameMatchIdAsync() => (await GetCurrentGamePlayerAsync())?.MatchId;
 
-		public async Task<CurrentGameMatch?> GetCurrentGameMatchAsync() => await initiator.ExternalSystem.Net.GetAsync<CurrentGameMatch>(Url, $"/core-game/v1/matches/{await GetCurrentGameMatchIdAsync()}");
+		public async Task<CurrentGameMatch?> GetCurrentGameMatchAsync()
+		{
+			string? matchId = await GetCurrentGameMatchIdAsync();
+			if (matchId.IsNullOrEmpty())
+				return null;
 
-		public async Task<GameLoadout?> GetCurrentGameLoadoutsAsync() => await initiator.ExternalSystem.Net.GetAsync<GameLoadout>(Url, $"/core-game/v1/matches/{await GetCurrentGameMatchIdAsync()}");
+			return await initiator.ExternalSystem.Net.GetAsync<CurrentGameMatch>(Url, $"/core-game/v1/matches/{matchId}");
+		}
+
+		public async Task<GameLoadout?> GetCurrentGameLoadoutsAsync()
+		{
+			string? matchId = await GetCurrentGameMatchIdAsync();
+			if (matchId.IsNullOrEmpty())
+				return null;
+
+			return await initiator.ExternalSystem.Net.GetAsync<GameLoadout>(Url, $"/core-game/v1/matches/{matchId}");
+		}
+
+		public async Task QuitCurrentGameAsync()
+		{
+			string? matchId = await GetCurrentGameMatchIdAsync();
+			if (matchId.IsNullOrEmpty())
+				return;
+
+			await initiator.ExternalSystem.Net.PostAsync(Url, $"/core-game/v1/players/{initiator.Client.UserId}/disassociate/{matchId}").ConfigureAwait(false);
+		}
+
+
+		public async Task<CurrentSession?> GetCurrentSession() => await initiator.ExternalSystem.Net.GetAsync<CurrentSession>(Url, $"/session/v1/sessions/{initiator.Client.UserId}");
+
 
 		[Obsolete("Ambiguous spelling, please use newer method 'GetCurrentGameLoadoutsAsync'")]
 		public async Task<GameLoadout?> GetCurrentGameLoadoutAsync() => await GetCurrentGameLoadoutsAsync();
-
-		// Need to get data return
-		public async Task<CurrentSession?> GetCurrentSession() => await initiator.ExternalSystem.Net.GetAsync<CurrentSession>(Url, $"/session/v1/sessions/{initiator.Client.UserId}");
-
-		public async Task QuitCurrentGameAsync() => await initiator.ExternalSystem.Net.PostAsync(Url, $"/core-game/v1/players/{initiator.Client.UserId}/disassociate/{await GetCurrentGameMatchIdAsync()}");
 	}
 }

--- a/Network/PVPEndpoints/PVPEndpoints.cs
+++ b/Network/PVPEndpoints/PVPEndpoints.cs
@@ -1,5 +1,6 @@
 ﻿using RadiantConnect.Network.PVPEndpoints.DataTypes;
 using RadiantConnect.Services;
+using System.Net.Http.Headers;
 
 // ReSharper disable All
 
@@ -33,10 +34,11 @@ namespace RadiantConnect.Network.PVPEndpoints
 
 		public async Task<PlayerLoadout?> SetPlayerLoadoutAsync(SetPlayerLoadout newLoadout) => await initiator.ExternalSystem.Net.PutAsync<PlayerLoadout>(Url, $"personalization/v2/players/{initiator.Client.UserId}/playerloadout", JsonContent.Create(newLoadout));
 
-		public async Task<NameService?> FetchNameServiceReturn(params string[] userIds)
+		public async Task<List<NameService>?> FetchNameServiceReturn(params string[] userIds)
 		{
-			List<NameService>? namesData = await initiator.ExternalSystem.Net.PutAsync<List<NameService>>(Url, "name-service/v2/players", new StringContent(JsonSerializer.Serialize(userIds)));
-			return namesData == null || namesData.Count == 0 ? null : namesData[0];
+			StringContent jsonData = new StringContent(JsonSerializer.Serialize(userIds), MediaTypeHeaderValue.Parse("application/json"));
+			List<NameService>? namesData = await initiator.ExternalSystem.Net.PutAsync<List<NameService>>(Url, "name-service/v2/players", jsonData);
+			return namesData;
 		} 
 	}
 }

--- a/Network/PartyEndpoints/PartyEndpoints.cs
+++ b/Network/PartyEndpoints/PartyEndpoints.cs
@@ -12,56 +12,175 @@ namespace RadiantConnect.Network.PartyEndpoints
 		public async Task<PartyPlayer?> FetchPartyPlayerAsync() => await initiator.ExternalSystem.Net.GetAsync<PartyPlayer>(Url, $"parties/v1/players/{initiator.Client.UserId}");
 
 		private async Task<string?> FetchPartyIdAsync() => (await FetchPartyPlayerAsync())?.CurrentPartyID;
+		public async Task<Party?> FetchPartyAsync()
+		{
+			string? partyId = await FetchPartyIdAsync();
+			if (partyId.IsNullOrEmpty())
+				return null;
 
-		public async Task<Party?> FetchPartyAsync() => await initiator.ExternalSystem.Net.GetAsync<Party>(Url, $"parties/v1/parties/{await FetchPartyIdAsync()}");
+			return await initiator.ExternalSystem.Net
+				.GetAsync<Party>(Url, $"parties/v1/parties/{partyId}");
+		}
 
-		public async Task<CustomGameConfig?> FetchCustomGameConfigAsync() => await initiator.ExternalSystem.Net.GetAsync<CustomGameConfig>(Url, "parties/v1/parties/customgameconfigs");
+		public async Task<CustomGameConfig?> FetchCustomGameConfigAsync()
+		{
+			return await initiator.ExternalSystem.Net
+				.GetAsync<CustomGameConfig>(Url, "parties/v1/parties/customgameconfigs");
+		}
 
-		public async Task<PartyChatToken?> FetchPartyChatTokenAsync() => await initiator.ExternalSystem.Net.GetAsync<PartyChatToken>(Url, $"parties/v1/parties/{await FetchPartyIdAsync()}/muctoken");
+		public async Task<PartyChatToken?> FetchPartyChatTokenAsync()
+		{
+			string? partyId = await FetchPartyIdAsync();
+			if (partyId.IsNullOrEmpty())
+				return null;
 
-		public async Task<PartyVoiceToken?> FetchPartyVoiceTokenAsync() => await initiator.ExternalSystem.Net.GetAsync<PartyVoiceToken>(Url, $"parties/v1/parties/{await FetchPartyIdAsync()}/voicetoken");
+			return await initiator.ExternalSystem.Net
+				.GetAsync<PartyChatToken>(Url, $"parties/v1/parties/{partyId}/muctoken");
+		}
+
+		public async Task<PartyVoiceToken?> FetchPartyVoiceTokenAsync()
+		{
+			string? partyId = await FetchPartyIdAsync();
+			if (partyId.IsNullOrEmpty())
+				return null;
+
+			return await initiator.ExternalSystem.Net
+				.GetAsync<PartyVoiceToken>(Url, $"parties/v1/parties/{partyId}/voicetoken");
+		}
 
 		public async Task<PartySetReady?> SetPartyReadyAsync(bool ready)
 		{
-			JsonContent jsonContent = JsonContent.Create(new NameValueCollection() { { "ready", ready.ToString() } });
-			return await initiator.ExternalSystem.Net.PostAsync<PartySetReady>(Url, $"parties/v1/parties/{await FetchPartyIdAsync()}/members/{initiator.Client.UserId}/setReady", jsonContent);
+			string? partyId = await FetchPartyIdAsync();
+			if (partyId.IsNullOrEmpty())
+				return null;
+
+			JsonContent jsonContent = JsonContent.Create(
+				new NameValueCollection() { { "ready", ready.ToString() } });
+
+			return await initiator.ExternalSystem.Net
+				.PostAsync<PartySetReady>(Url, $"parties/v1/parties/{partyId}/members/{initiator.Client.UserId}/setReady", jsonContent);
 		}
 
-		public async Task<Party?> RefreshCompetitveTierAsync() => await initiator.ExternalSystem.Net.PostAsync<Party>(Url, $"parties/v1/parties/{await FetchPartyIdAsync()}/members/{initiator.Client.UserId}/refreshCompetitiveTier");
+		public async Task<Party?> RefreshCompetitveTierAsync()
+		{
+			string? partyId = await FetchPartyIdAsync();
+			if (partyId.IsNullOrEmpty())
+				return null;
 
-		public async Task<Party?> RefreshPlayerIdentityAsync() => await initiator.ExternalSystem.Net.PostAsync<Party>(Url, $"parties/v1/parties/{await FetchPartyIdAsync()}/members/{initiator.Client.UserId}/refreshPlayerIdentity");
+			return await initiator.ExternalSystem.Net
+				.PostAsync<Party>(Url, $"parties/v1/parties/{partyId}/members/{initiator.Client.UserId}/refreshCompetitiveTier");
+		}
 
-		public async Task<Party?> RefreshPingsAsync() => await initiator.ExternalSystem.Net.PostAsync<Party>(Url, $"parties/v1/parties/{await FetchPartyIdAsync()}/members/{initiator.Client.UserId}/refreshPings");
+		public async Task<Party?> RefreshPlayerIdentityAsync()
+		{
+			string? partyId = await FetchPartyIdAsync();
+			if (partyId.IsNullOrEmpty())
+				return null;
+
+			return await initiator.ExternalSystem.Net
+				.PostAsync<Party>(Url, $"parties/v1/parties/{partyId}/members/{initiator.Client.UserId}/refreshPlayerIdentity");
+		}
+
+		public async Task<Party?> RefreshPingsAsync()
+		{
+			string? partyId = await FetchPartyIdAsync();
+			if (partyId.IsNullOrEmpty())
+				return null;
+
+			return await initiator.ExternalSystem.Net
+				.PostAsync<Party>(Url, $"parties/v1/parties/{partyId}/members/{initiator.Client.UserId}/refreshPings");
+		}
 
 		public async Task<Party?> ChangeQueueAsync(ValorantTables.QueueId queueId)
 		{
+			string? partyId = await FetchPartyIdAsync();
+			if (partyId.IsNullOrEmpty())
+				return null;
+
 			JsonContent jsonContent = JsonContent.Create(new { queueID = queueId.ToString() });
-			return await initiator.ExternalSystem.Net.PostAsync<Party>(Url, $"parties/v1/parties/{await FetchPartyIdAsync()}/queue",  jsonContent);
+
+			return await initiator.ExternalSystem.Net
+				.PostAsync<Party>(Url, $"parties/v1/parties/{partyId}/queue", jsonContent);
 		}
 
-		public async Task<Party?> StartCustomGameAsync() => await initiator.ExternalSystem.Net.PostAsync<Party>(Url, $"parties/v1/parties/{await FetchPartyIdAsync()}/startcustomgame");
+		public async Task<Party?> StartCustomGameAsync()
+		{
+			string? partyId = await FetchPartyIdAsync();
+			if (partyId.IsNullOrEmpty())
+				return null;
 
-		public async Task<Party?> EnterQueueAsync() => await initiator.ExternalSystem.Net.PostAsync<Party>(Url, $"parties/v1/parties/{await FetchPartyIdAsync()}/matchmaking/join");
+			return await initiator.ExternalSystem.Net
+				.PostAsync<Party>(Url, $"parties/v1/parties/{partyId}/startcustomgame");
+		}
 
-		public async Task<Party?> LeaveQueueAsync() => await initiator.ExternalSystem.Net.PostAsync<Party>(Url, $"parties/v1/parties/{await FetchPartyIdAsync()}/matchmaking/leave");
+		public async Task<Party?> EnterQueueAsync()
+		{
+			string? partyId = await FetchPartyIdAsync();
+			if (partyId.IsNullOrEmpty())
+				return null;
+
+			return await initiator.ExternalSystem.Net
+				.PostAsync<Party>(Url, $"parties/v1/parties/{partyId}/matchmaking/join");
+		}
+
+		public async Task<Party?> LeaveQueueAsync()
+		{
+			string? partyId = await FetchPartyIdAsync();
+			if (partyId.IsNullOrEmpty())
+				return null;
+
+			return await initiator.ExternalSystem.Net
+				.PostAsync<Party>(Url, $"parties/v1/parties/{partyId}/matchmaking/leave");
+		}
 
 		public async Task<Party?> SetPartyOpenStatusAsync(ValorantTables.PartyState state)
 		{
-			JsonContent jsonContent = JsonContent.Create(new NameValueCollection() { { "accessibility", state.ToString() } });
-			return await initiator.ExternalSystem.Net.PostAsync<Party>(Url, $"parties/v1/parties/{await FetchPartyIdAsync()}/accessibility",  jsonContent);
+			string? partyId = await FetchPartyIdAsync();
+			if (partyId.IsNullOrEmpty())
+				return null;
+
+			JsonContent jsonContent = JsonContent.Create(
+				new NameValueCollection() { { "accessibility", state.ToString() } });
+
+			return await initiator.ExternalSystem.Net
+				.PostAsync<Party>(Url, $"parties/v1/parties/{partyId}/accessibility", jsonContent);
 		}
 
 		public async Task<Party?> SetCustomGameSettingsAsync(CustomGameSettings gameSettings)
 		{
+			string? partyId = await FetchPartyIdAsync();
+			if (partyId.IsNullOrEmpty())
+				return null;
+
 			JsonContent jsonContent = JsonContent.Create(gameSettings);
-			return await initiator.ExternalSystem.Net.PostAsync<Party>(Url, $"parties/v1/parties/{await FetchPartyIdAsync()}/customgamesettings", jsonContent);
+
+			return await initiator.ExternalSystem.Net
+				.PostAsync<Party>(Url, $"parties/v1/parties/{partyId}/customgamesettings", jsonContent);
 		}
 
-		public async Task EnterCustomGameQueue() => await initiator.ExternalSystem.Net.PostAsync(Url, $"parties/v1/parties/{await FetchPartyIdAsync()}/makecustomgame");
+		public async Task EnterCustomGameQueue()
+		{
+			string? partyId = await FetchPartyIdAsync();
+			if (partyId.IsNullOrEmpty())
+				return;
+
+			await initiator.ExternalSystem.Net
+				.PostAsync(Url, $"parties/v1/parties/{partyId}/makecustomgame");
+		}
+
 		public async Task EnterCustomGame() => await EnterCustomGameQueue();
+
 		public async Task SwitchToCustomGame() => await EnterCustomGameQueue();
 
-		public async Task<Party?> InvitePlayerAsync(string name, string tagLine) => await initiator.ExternalSystem.Net.PostAsync<Party>(Url, $"parties/v1/parties/{await FetchPartyIdAsync()}/invites/name/{name}/tag/{tagLine}");
+		public async Task<Party?> InvitePlayerAsync(string name, string tagLine)
+		{
+			string? partyId = await FetchPartyIdAsync();
+			if (partyId.IsNullOrEmpty())
+				return null;
+
+			return await initiator.ExternalSystem.Net
+				.PostAsync<Party>(Url, $"parties/v1/parties/{partyId}/invites/name/{name}/tag/{tagLine}");
+		}
 
 		public async Task KickFromPartyAsync(string userId) => await initiator.ExternalSystem.Net.DeleteAsync(Url, $"parties/v1/players/{userId}");
 

--- a/Network/PartyEndpoints/PartyEndpoints.cs
+++ b/Network/PartyEndpoints/PartyEndpoints.cs
@@ -22,11 +22,7 @@ namespace RadiantConnect.Network.PartyEndpoints
 				.GetAsync<Party>(Url, $"parties/v1/parties/{partyId}");
 		}
 
-		public async Task<CustomGameConfig?> FetchCustomGameConfigAsync()
-		{
-			return await initiator.ExternalSystem.Net
-				.GetAsync<CustomGameConfig>(Url, "parties/v1/parties/customgameconfigs");
-		}
+		public async Task<CustomGameConfig?> FetchCustomGameConfigAsync() => await initiator.ExternalSystem.Net.GetAsync<CustomGameConfig>(Url, "parties/v1/parties/customgameconfigs");
 
 		public async Task<PartyChatToken?> FetchPartyChatTokenAsync()
 		{

--- a/Network/PreGameEndpoints/PreGameEndpoints.cs
+++ b/Network/PreGameEndpoints/PreGameEndpoints.cs
@@ -11,15 +11,51 @@ namespace RadiantConnect.Network.PreGameEndpoints
 		public async Task<PreGamePlayer?> FetchPreGamePlayerAsync() => await initiator.ExternalSystem.Net.GetAsync<PreGamePlayer>(Url, $"/pregame/v1/players/{initiator.Client.UserId}");
 
 		public async Task<string?> FetchPreGameMatchId() => (await FetchPreGamePlayerAsync())?.MatchId;
+		
+		public async Task<PreGameMatch?> FetchPreGameMatchAsync()
+		{
+			string? matchId = await FetchPreGameMatchId();
+			if (matchId.IsNullOrEmpty())
+				return null;
 
-		public async Task<PreGameMatch?> FetchPreGameMatchAsync() => await initiator.ExternalSystem.Net.GetAsync<PreGameMatch>(Url, $"/pregame/v1/matches/{await FetchPreGameMatchId()}");
+			return await initiator.ExternalSystem.Net.GetAsync<PreGameMatch>(Url, $"/pregame/v1/matches/{matchId}");
+		}
 
-		public async Task<GameLoadout?> FetchPreGameLoadoutAsync() => await initiator.ExternalSystem.Net.GetAsync<GameLoadout>(Url, $"/pregame/v1/matches/{await FetchPreGameMatchId()}/loadouts");
+		public async Task<GameLoadout?> FetchPreGameLoadoutAsync()
+		{
+			string? matchId = await FetchPreGameMatchId();
+			if (matchId.IsNullOrEmpty())
+				return null;
 
-		public async Task<PreGameMatch?> SelectCharacterAsync(ValorantTables.Agent agent) => await initiator.ExternalSystem.Net.PostAsync<PreGameMatch>(Url, $"/pregame/v1/matches/{await FetchPreGameMatchId()}/select/{ValorantTables.AgentToId[agent]}");
+			return await initiator.ExternalSystem.Net.GetAsync<GameLoadout>(Url, $"/pregame/v1/matches/{matchId}/loadouts");
+		}
 
-		public async Task<PreGameMatch?> LockCharacterAsync(ValorantTables.Agent agent) => await initiator.ExternalSystem.Net.PostAsync<PreGameMatch>(Url, $"/pregame/v1/matches/{await FetchPreGameMatchId()}/lock/{ValorantTables.AgentToId[agent]}");
+		public async Task<PreGameMatch?> SelectCharacterAsync(ValorantTables.Agent agent)
+		{
+			string? matchId = await FetchPreGameMatchId();
+			if (matchId.IsNullOrEmpty())
+				return null;
 
-		public async Task QuitGameAsync() => await initiator.ExternalSystem.Net.PostAsync(Url, $"/pregame/v1/matches/{await FetchPreGameMatchId()}/quit").ConfigureAwait(false);
+			return await initiator.ExternalSystem.Net.PostAsync<PreGameMatch>(Url, $"/pregame/v1/matches/{matchId}/select/{ValorantTables.AgentToId[agent]}");
+		}
+
+		public async Task<PreGameMatch?> LockCharacterAsync(ValorantTables.Agent agent)
+		{
+			string? matchId = await FetchPreGameMatchId();
+			if (matchId.IsNullOrEmpty())
+				return null;
+
+			return await initiator.ExternalSystem.Net.PostAsync<PreGameMatch>(Url, $"/pregame/v1/matches/{matchId}/lock/{ValorantTables.AgentToId[agent]}");
+		}
+
+		public async Task QuitGameAsync()
+		{
+			string? matchId = await FetchPreGameMatchId();
+			if (matchId.IsNullOrEmpty())
+				return;
+			
+			await initiator.ExternalSystem.Net.PostAsync(Url, $"/pregame/v1/matches/{matchId}/quit").ConfigureAwait(false);
+		}
+
 	}
 }

--- a/Network/ValorantNet.cs
+++ b/Network/ValorantNet.cs
@@ -258,7 +258,6 @@ namespace RadiantConnect.Network
 						backoffDelayMs *= 2;
 						break;
 					case 404:
-						OnLog?.Invoke($"\n[ValorantNet Log] Uri: (404 Not Found) {baseUrl}{endPoint}\n[ValorantNet Log] Request Headers:{JsonSerializer.Serialize(_client.DefaultRequestHeaders.ToDictionary())}\n[ValorantNet Log] Request Content: {JsonSerializer.Serialize(content)}\n[ValorantNet Log] Response Content:{responseContent}\n[ValorantNet Log] Response Data: {responseMessage}");
 						return null;
 					default:
 						throw new RadiantConnectNetworkStatusException($"\n[ValorantNet Log] Uri:{baseUrl}{endPoint}\n[ValorantNet Log] Request Headers:{JsonSerializer.Serialize(_client.DefaultRequestHeaders.ToDictionary())}\n[ValorantNet Log] Request Content: {JsonSerializer.Serialize(content)}\n[ValorantNet Log] Response Content:{responseContent}\n[ValorantNet Log] Response Data: {responseMessage}");

--- a/Network/ValorantNet.cs
+++ b/Network/ValorantNet.cs
@@ -1,6 +1,7 @@
-﻿using System.Net.Http.Headers;
-using RadiantConnect.Authentication.DriverRiotAuth.Records;
+﻿using RadiantConnect.Authentication.DriverRiotAuth.Records;
 using RadiantConnect.Services;
+using System.Net.Http.Headers;
+
 
 #pragma warning disable IDE0046
 
@@ -47,6 +48,8 @@ namespace RadiantConnect.Network
         private readonly string _defaultPlatform;
         private readonly string _defaultUserAgent;
         private readonly string _defaultClientVersion;
+
+        private readonly Cache _cache = new();
 
         private void ResetDefaultHeaders()
         {
@@ -114,7 +117,7 @@ namespace RadiantConnect.Network
 
             if (AuthCodes is not null)
             {
-				if (string.IsNullOrEmpty(AuthCodes.AccessToken) || string.IsNullOrEmpty(AuthCodes.Entitlement)) 
+				if (AuthCodes.AccessToken.IsNullOrEmpty() || AuthCodes.Entitlement.IsNullOrEmpty()) 
 					throw new RadiantConnectException("AuthCodes are not valid, AccessToken or EntitlementToken is empty.");
 				
 				return (AuthCodes.AccessToken, AuthCodes.Entitlement);
@@ -131,7 +134,7 @@ namespace RadiantConnect.Network
             return (entitlement?.AccessToken ?? "", entitlement?.Token ?? "");
         }
        
-        private async Task ResetAuth()
+        private async Task ResetAuth(bool resetAuth = false)
         {
             try
             {
@@ -140,16 +143,29 @@ namespace RadiantConnect.Network
             }
             catch {/**/}
 
-            (string, string) authTokens = await GetAuthorizationToken();
+            if (!resetAuth && !_cache.AccessToken.IsNullOrEmpty() && !_cache.Jwt.IsNullOrEmpty())
+            {
+	            _client.DefaultRequestHeaders.Authorization = AuthenticationHeaderValue.Parse($"Bearer {_cache.AccessToken}");
+	            _client.DefaultRequestHeaders.TryAddWithoutValidation("X-Riot-Entitlements-JWT", _cache.Jwt);
+
+				OnLog?.Invoke("[ValorantNet Log] Using cached Auth Tokens");
+
+				return;
+            }
+
+			(string, string) authTokens = await GetAuthorizationToken();
 
             if (authTokens.Item1.IsNullOrEmpty()) throw new RadiantConnectException("Failed to get Authorization Token");
             if (authTokens.Item2.IsNullOrEmpty()) throw new RadiantConnectException("Failed to get JWT Token");
+
+			_cache.AccessToken = authTokens.Item1;
+			_cache.Jwt = authTokens.Item2;
 
 			_client.DefaultRequestHeaders.Authorization = AuthenticationHeaderValue.Parse($"Bearer {authTokens.Item1}");
             _client.DefaultRequestHeaders.TryAddWithoutValidation("X-Riot-Entitlements-JWT", authTokens.Item2);
         }
 
-        private Task SetBasicAuth()
+        private Task SetBasicAuth(bool resetAuth = false)
         {
             OnLog?.Invoke("[ValorantNet Log] Settings Basic Auth");
 
@@ -159,7 +175,15 @@ namespace RadiantConnect.Network
             _client.DefaultRequestHeaders.Remove("X-Riot-Entitlements-JWT");
             _client.DefaultRequestHeaders.Remove("Authorization");
 
-            _client.DefaultRequestHeaders.Authorization = AuthenticationHeaderValue.Parse($"Basic {$"riot:{GetAuth()?.OAuth}".ToBase64()}");
+            if (!resetAuth && !_cache.Basic.IsNullOrEmpty())
+            {
+	            _client.DefaultRequestHeaders.Authorization = AuthenticationHeaderValue.Parse($"Basic {_cache.Basic}");
+	            return Task.CompletedTask;
+            }
+
+            _cache.Basic = $"riot:{GetAuth()?.OAuth}".ToBase64();
+            
+            _client.DefaultRequestHeaders.Authorization = AuthenticationHeaderValue.Parse($"Basic {_cache.Basic}");
 
             return Task.CompletedTask;
         }
@@ -172,9 +196,16 @@ namespace RadiantConnect.Network
                 _client.DefaultRequestHeaders.TryAddWithoutValidation(key, value);
         }
 
+        public class Cache
+        {
+			public string Jwt { get; set; } = string.Empty;
+			public string AccessToken { get; set; } = string.Empty;
+			public string Basic { get; set; } = string.Empty;
+		}
+
         public async Task<string?> CreateRequest(HttpMethod httpMethod, string baseUrl, string endPoint, HttpContent? content = null, Dictionary<string, string>? customHeaders = null)
         {
-            if (baseUrl.IsNullOrEmpty()) return string.Empty;
+			if (baseUrl.IsNullOrEmpty()) return string.Empty;
 
             if (!endPoint.IsNullOrEmpty())
             {
@@ -182,32 +213,61 @@ namespace RadiantConnect.Network
                 if (baseUrl[^1] != '/' && endPoint[0] != '/') baseUrl += "/"; // Make sure it actually contains a slash
             }
 
-            // I no longer need the loop, as the client will now handle edge-cases.
             if (!(InternalValorantMethods.IsValorantProcessRunning() || InternalValorantMethods.IsRiotClientRunning()) && AuthCodes is null) return string.Empty;
 
-            if (baseUrl.Contains("127.0.0.1") && _client.DefaultRequestHeaders.Authorization?.Scheme != "Basic") await SetBasicAuth();
-            else if (customHeaders is not null) SetCustomHeaders(customHeaders);
-            else if (!baseUrl.Contains("127.0.0.1")) await ResetAuth();
+			const int maxRetries = 5;
+			int retryCount = 0;
+			int backoffDelayMs = 5000;
+			bool resetCache = false;
 
-            using HttpRequestMessage httpRequest = new();
-            httpRequest.Method = MapHttpMethod(httpMethod);
-            httpRequest.RequestUri = new Uri($"{baseUrl}{endPoint}");
-            httpRequest.Content = content;
+			while (retryCount < maxRetries)
+			{
+				// Set authentication headers
+				if (baseUrl.Contains("127.0.0.1") && _client.DefaultRequestHeaders.Authorization?.Scheme != "Basic") await SetBasicAuth(resetCache);
+				else if (customHeaders is not null) SetCustomHeaders(customHeaders);
+				else if (!baseUrl.Contains("127.0.0.1")) await ResetAuth(resetCache);
 
-            using HttpResponseMessage responseMessage = await _client.SendAsync(httpRequest, HttpCompletionOption.ResponseContentRead).ConfigureAwait(false);
+				using HttpRequestMessage httpRequest = new();
+				httpRequest.Method = MapHttpMethod(httpMethod);
+				httpRequest.RequestUri = new Uri($"{baseUrl}{endPoint}");
+				httpRequest.Content = content;
 
-            string responseContent = await responseMessage.Content.ReadAsStringAsync();
+				using HttpResponseMessage responseMessage = await _client.SendAsync(httpRequest, HttpCompletionOption.ResponseContentRead).ConfigureAwait(false);
+				string responseContent = await responseMessage.Content.ReadAsStringAsync();
 
-            if (customHeaders is not null)
-                ResetDefaultHeaders();
+				if (customHeaders is not null)
+					ResetDefaultHeaders();
 
-            OnLog?.Invoke($"[ValorantNet Log] Uri:{baseUrl}{endPoint}\n[ValorantNet Log] Request Headers:{JsonSerializer.Serialize(_client.DefaultRequestHeaders.ToDictionary())}\n[ValorantNet Log] Request Content: {JsonSerializer.Serialize(content)}\n[ValorantNet Log] Response Content:{responseContent}\n[ValorantNet Log] Response Data: {responseMessage}");
+				OnLog?.Invoke($"[ValorantNet Log] Uri:{baseUrl}{endPoint}\n[ValorantNet Log] Request Headers:{JsonSerializer.Serialize(_client.DefaultRequestHeaders.ToDictionary())}\n[ValorantNet Log] Request Content: {JsonSerializer.Serialize(content)}\n[ValorantNet Log] Response Content:{responseContent}\n[ValorantNet Log] Response Data: {responseMessage}");
 
-            return !responseMessage.IsSuccessStatusCode
-	            ? throw new RadiantConnectNetworkStatusException(
-		            $"\n[ValorantNet Log] Uri:{baseUrl}{endPoint}\n[ValorantNet Log] Request Headers:{JsonSerializer.Serialize(_client.DefaultRequestHeaders.ToDictionary())}\n[ValorantNet Log] Request Content: {JsonSerializer.Serialize(content)}\n[ValorantNet Log] Response Content:{responseContent}\n[ValorantNet Log] Response Data: {responseMessage}")
-	            : responseContent;
-        }
+				HttpStatusCode statusCode = responseMessage.StatusCode;
+
+				switch ((int)statusCode)
+				{
+					case 200:
+						return responseContent;
+					case 401:
+					case 403:
+						OnLog?.Invoke("[ValorantNet Log] Unauthorized/Forbidden, resetting cache and retrying.");
+						resetCache = true;
+						break;
+					case 429:
+						OnLog?.Invoke($"[ValorantNet Log] Rate limited, waiting {backoffDelayMs / 1000} seconds before retrying.");
+						await Task.Delay(backoffDelayMs);
+						backoffDelayMs *= 2;
+						break;
+					default:
+						throw new RadiantConnectNetworkStatusException($"\n[ValorantNet Log] Uri:{baseUrl}{endPoint}\n[ValorantNet Log] Request Headers:{JsonSerializer.Serialize(_client.DefaultRequestHeaders.ToDictionary())}\n[ValorantNet Log] Request Content: {JsonSerializer.Serialize(content)}\n[ValorantNet Log] Response Content:{responseContent}\n[ValorantNet Log] Response Data: {responseMessage}");
+				}
+				
+				retryCount++;
+				if (!resetCache) return responseContent;
+			}
+
+			throw new RadiantConnectNetworkStatusException(
+				$"[ValorantNet Log] Failed after {maxRetries} retries. Uri:{baseUrl}{endPoint}");
+
+		}
 
         public async Task<T?> GetAsync<T>(string baseUrl, string endPoint) 
             => await SendAndConvertAsync<T>(HttpMethod.Get, baseUrl, endPoint);

--- a/RConnect/RConnectMethods.cs
+++ b/RConnect/RConnectMethods.cs
@@ -99,9 +99,14 @@ namespace RadiantConnect.RConnect
 
         public static async Task<string?> GetRiotIdByPuuidAsync(this Initiator initiator, string puuid)
         {
-            NameService? serviceResponse = await initiator.Endpoints.PvpEndpoints.FetchNameServiceReturn(puuid);
+            List<NameService>? serviceResponse = await initiator.Endpoints.PvpEndpoints.FetchNameServiceReturn(puuid);
            
-            return $"{serviceResponse?.GameName}#{serviceResponse?.TagLine}";
+			if (serviceResponse == null) return null;
+			if (serviceResponse.Count == 0) return null;
+
+			NameService userId = serviceResponse[0];
+
+			return $"{userId?.GameName}#{userId?.TagLine}";
         }
 
         public static async Task<string?> GetPuuidByNameAsync(this Initiator initiator, string gameName, string tagLine)

--- a/RadiantConnect.csproj
+++ b/RadiantConnect.csproj
@@ -8,7 +8,7 @@
 		<GenerateDocumentationFile>False</GenerateDocumentationFile>
 		<GeneratePackageOnBuild>True</GeneratePackageOnBuild>
 		<Title>Radiant Connect Valorant API (UnOfficial)</Title>
-		<Version>10.3.1</Version>
+		<Version>10.4.0</Version>
 		<Authors>IrisDev</Authors>
 		<PackageProjectUrl>https://radiantconnect.ca/</PackageProjectUrl>
 		<RepositoryUrl>https://github.com/RiisDev/RadiantConnect</RepositoryUrl>
@@ -21,21 +21,22 @@
 		<PackageTags>valorant;valorant api;.net;dotnet;api;xmpp;mitm;authentication;game events;tcp;pvp;socket;realtime;multiplayer;open source;csharp;c#;websocket;game development</PackageTags>
 		<LangVersion>preview</LangVersion>
 		<PackageReleaseNotes>
-			* Fix RSOAuth ValorantNet UserAgent
-
-			------------
-
-			+ New Authentication method `AuthenticateWithLockFile`
-			+ New Game Event Handler `Initiator.TcpEvents` for TCP Game Events
-			+ Added PlayerCards, Totems/Flexes to ValorantTable ItemTypes
-			* Changed internal usage of valorant-api.com to api.radiantconnect.ca
-			* Added new scopes to AuthenticateWithSsid method
+			* Modified, PreGame,CurrentGame,Party endpoints to not double requests if not needed.
+			* Improved ValSocket performance on initiate.
+			* Improved GetRiotIdByPuuidAsync data.
+			* FetchNameServiceReturn now accepts and returns an array instead of single use.
+			* ValorantNet has been optimized and handles some error codes:
+			   * 404 no longer throws an exception but returns null.
+			   * 429 should now retry automatically up to 3 times with a built in delay.
+			   * Entitlement bug should also be fixed, report any issues.
+			* TcpEvents has a new event `OnPresenceUpdated` which returns base64 presence data decoded.
+			- ImageRecognition will most likely be removed in future versions, this is the last warning about it.
 		</PackageReleaseNotes>
 		<NeutralLanguage>en</NeutralLanguage>
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>
 		<PackageReadmeFile>README.md</PackageReadmeFile>
 		<RepositoryType>git</RepositoryType>
-		<AssemblyVersion>1.0.0.0</AssemblyVersion>
+		<AssemblyVersion>10.4.0</AssemblyVersion>
 		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 		<ErrorReport>none</ErrorReport>
 		<PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>

--- a/SocketServices/InternalTcp/TcpEvents.cs
+++ b/SocketServices/InternalTcp/TcpEvents.cs
@@ -11,6 +11,8 @@ namespace RadiantConnect.SocketServices.InternalTcp
 		private string _gamestate = "unknown";
 		private string _score = "unknown";
 
+		public delegate void PresenceUpdate(string base64);
+
 		public delegate void CurrencyEvent(string value);
 		public delegate void QueueEvent(string value);
 		public delegate void MatchChange(string value);
@@ -33,6 +35,8 @@ namespace RadiantConnect.SocketServices.InternalTcp
 		public event MmrEvent? OnMmrChanged;
 		public event ContractEvent? OnContractChanged;
 		public event Heartbeat? OnSessionHeartbeat;
+
+		public event PresenceUpdate? OnPresenceUpdated;
 
 		private readonly Initiator _initiator;
 
@@ -111,6 +115,8 @@ namespace RadiantConnect.SocketServices.InternalTcp
 			string presence64 = match.Groups[1].Value;
 			string jsonData = presence64.FromBase64();
 
+			OnPresenceUpdated?.Invoke(jsonData);
+			
 			Debug.WriteLine(jsonData);
 
 			JsonDocument jsonDocument = JsonDocument.Parse(jsonData);

--- a/SocketServices/InternalTcp/ValSocket.cs
+++ b/SocketServices/InternalTcp/ValSocket.cs
@@ -68,7 +68,9 @@ namespace RadiantConnect.SocketServices.InternalTcp
 	        {
 		        try
 		        {
-			        while (!await InternalValorantMethods.IsReady(Init.Endpoints.LocalEndpoints))
+					IReadOnlyList<string> events = await GetEvents();
+
+					while (events.Count == 0)
 			        {
 				        Debug.WriteLine("Waiting for ClientReady...");
 				        await Task.Delay(500);
@@ -81,7 +83,7 @@ namespace RadiantConnect.SocketServices.InternalTcp
 			        clientWebSocket.Options.SetRequestHeader("Authorization", $"Basic {$"riot:{Authentication?.OAuth}".ToBase64()}");
 			        await clientWebSocket.ConnectAsync(uri, CancellationToken.None);
 
-			        foreach (string eventName in await GetEvents()) 
+			        foreach (string eventName in events) 
 				        await clientWebSocket.SendAsync(new ArraySegment<byte>([.. Encoding.UTF8.GetBytes($"[5, \"{eventName}\"]")]), WebSocketMessageType.Text, true, CancellationToken.None);
 
 			        while (!ShutdownSocket.IsCancellationRequested) 

--- a/Utilities/InternalValorantMethods.cs
+++ b/Utilities/InternalValorantMethods.cs
@@ -1,5 +1,4 @@
-﻿using RadiantConnect.Network.LocalEndpoints;
-using RadiantConnect.Services;
+﻿using RadiantConnect.Services;
 
 namespace RadiantConnect.Utilities
 {
@@ -16,15 +15,5 @@ namespace RadiantConnect.Utilities
 		public static bool IsValorantProcessRunning() => Process.GetProcessesByName("VALORANT").Length > 0;
 
 		public static bool IsRiotClientRunning() => Process.GetProcessesByName("RiotClientServices").Length > 0 && Process.GetProcessesByName("Riot Client").Length > 0;
-		internal static async Task<bool> IsReady(LocalEndpoints localEndpoints)
-		{
-			try
-			{
-				JsonElement? response = await localEndpoints.GetHelpAsync();
-				bool exists = response?.TryGetProperty("events", out _) ?? false;
-				return exists;
-			}
-			catch { return false; }
-		}
 	}
 }


### PR DESCRIPTION
* Modified, PreGame,CurrentGame,Party endpoints to not double requests if not needed.
* Improved ValSocket performance on initiate.
* Improved GetRiotIdByPuuidAsync data.
* FetchNameServiceReturn now accepts and returns an array instead of single use.
* ValorantNet has been optimized and handles some error codes:
   * 404 no longer throws an exception but returns null.
   * 429 should now retry automatically up to 3 times with a built in delay.
   * Entitlement bug should also be fixed, report any issues.
* TcpEvents has a new event `OnPresenceUpdated` which returns base64 presence data decoded.